### PR TITLE
Add ES5 compatible dist

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/**
+ * @module  color-interpolate
+ * Pick color from palette by index
+ */
+
+var parse = require('color-parse');
+var hsl = require('color-space/hsl');
+var lerp = require('lerp');
+var clamp = require('mumath/clamp');
+
+module.exports = interpolate;
+
+function interpolate(palette) {
+	palette = palette.map(function (c) {
+		c = parse(c);
+		if (c.space != 'rgb') {
+			if (c.space != 'hsl') throw c.space + ' space is not supported.';
+			c.values = hsl.rgb(c.values);
+		}
+		c.values.push(c.alpha);
+		return c.values;
+	});
+
+	return function (t) {
+		var mix = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : lerp;
+
+		t = clamp(t, 0, 1);
+
+		var idx = (palette.length - 1) * t,
+		    lIdx = Math.floor(idx),
+		    rIdx = Math.ceil(idx);
+
+		t = idx - lIdx;
+
+		var lColor = palette[lIdx],
+		    rColor = palette[rIdx];
+
+		var result = lColor.map(function (v, i) {
+			v = mix(v, rColor[i], t);
+			if (i < 3) v = Math.round(v);
+			return v;
+		});
+
+		if (result[3] === 1) {
+			return 'rgb(' + result.slice(0, 3) + ')';
+		}
+		return 'rgba(' + result + ')';
+	};
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "color-interpolate",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Pick color from a given color palette by index",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
-    "test": "node test"
+    "test": "node test",
+    "build": "babel index.js --presets babel-preset-es2015 --out-dir dist"
   },
   "repository": {
     "type": "git",
@@ -33,5 +34,9 @@
     "color-space": "^1.14.3",
     "lerp": "^1.0.3",
     "mumath": "^3.0.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.24.1",
+    "babel-preset-es2015": "^6.24.1"
   }
 }


### PR DESCRIPTION
This commit adds an ES5 dist version. Includes:

- `/dist` : transpiled ES5 version
-`build` script to transpile and update `/dist`
- `babel-cl` and `babel-preset-es2015` as devDepencies

This is useful when working with older projects without a transpilation pipeline