### PR TITLE
Fix type of index parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module "color-interpolate" {
-    function interpolate(palette: string[]): (number) => string
+    function interpolate(palette: string[]): (index: number) => string
 
     export = interpolate
 }


### PR DESCRIPTION
The type of the index parameter was previously not defined, which caused a TS compilation error.