### PR TITLE
Fix github links in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/dy/color-interpolate.git"
+    "url": "git+https://github.com/colorjs/color-interpolate.git"
   },
   "keywords": [
     "color",
@@ -26,9 +26,9 @@
   "author": "ΔY <dfcreative@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/dy/color-interpolate/issues"
+    "url": "https://github.com/colorjs/color-interpolate/issues"
   },
-  "homepage": "https://github.com/dy/color-interpolate#readme",
+  "homepage": "https://github.com/colorjs/color-interpolate#readme",
   "dependencies": {
     "clamp": "^1.0.1",
     "color-parse": "^1.2.0",


### PR DESCRIPTION
The `npm` package page is where most people find this, they might think the project was abandoned...