### PR TITLE
Downgrade dependencies to CommonJS compatible versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
  * Pick color from palette by index
  */
 
-const parse = require('color-parse').default;
+const parse = require('color-parse');
 const hsl = require('color-space/hsl');
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,41 +1,64 @@
 {
   "name": "color-interpolate",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "color-interpolate",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
-        "color-parse": "^2.0.2",
-        "color-space": "^2.3.2"
+        "color-parse": "^1.4.3",
+        "color-space": "^1.16.0"
       }
+    },
+    "node_modules/almost-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/almost-equal/-/almost-equal-1.1.0.tgz",
+      "integrity": "sha512-0V/PkoculFl5+0Lp47JoxUcO0xSxhIBvm+BxHdD/OgXNmdRpRHCFnKVuUoWyS9EzQP+otSGv0m9Lb4yVkQBn2A==",
+      "license": "MIT"
     },
     "node_modules/color-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
-      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      }
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/color-parse": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
-      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.3.tgz",
+      "integrity": "sha512-BADfVl/FHkQkyo8sRBwMYBqemqsgnu7JZAwUgvBvuwwuNUZAhSvLTbsEErS5bQXzOjDR0dWzJ4vXN2Q+QoPx0A==",
       "license": "MIT",
       "dependencies": {
-        "color-name": "^2.0.0"
+        "color-name": "^1.0.0"
       }
     },
     "node_modules/color-space": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/color-space/-/color-space-2.3.2.tgz",
-      "integrity": "sha512-BcKnbOEsOarCwyoLstcoEztwT0IJxqqQkNwDuA3a65sICvvHL2yoeV13psoDFh5IuiOMnIOKdQDwB4Mk3BypiA==",
-      "license": "Unlicense"
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/color-space/-/color-space-1.16.0.tgz",
+      "integrity": "sha512-A6WMiFzunQ8KEPFmj02OnnoUnqhmSaHaZ/0LVFcPTdlvm8+3aMJ5x1HRHy3bDHPkovkf4sS0f4wsVvwk71fKkg==",
+      "license": "MIT",
+      "dependencies": {
+        "hsluv": "^0.0.3",
+        "mumath": "^3.3.4"
+      }
+    },
+    "node_modules/hsluv": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/hsluv/-/hsluv-0.0.3.tgz",
+      "integrity": "sha512-08iL2VyCRbkQKBySkSh6m8zMUa3sADAxGVWs3Z1aPcUkTJeK0ETG4Fc27tEmQBGUAXZjIsXOZqBvacuVNSC/fQ==",
+      "license": "MIT"
+    },
+    "node_modules/mumath": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/mumath/-/mumath-3.3.4.tgz",
+      "integrity": "sha512-VAFIOG6rsxoc7q/IaY3jdjmrsuX9f15KlRLYTHmixASBZkZEKC1IFqE2BC5CdhXmK6WLM1Re33z//AGmeRI6FA==",
+      "deprecated": "Redundant dependency in your project.",
+      "license": "Unlicense",
+      "dependencies": {
+        "almost-equal": "^1.1.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "color-interpolate",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Pick color from a given color palette by index",
   "main": "index.js",
   "types": "index.d.ts",
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/colorjs/color-interpolate#readme",
   "dependencies": {
-    "color-parse": "^2.0.2",
-    "color-space": "^2.3.2"
+    "color-parse": "^1.4.3",
+    "color-space": "^1.16.0"
   }
 }


### PR DESCRIPTION
A mistake on my part in 3e47f2d upgraded the color-parse and color-space packages to v2.x. These new versions are ESM-only, which caused breaking changes for CommonJS consumers.

This commit reverts those specific package upgrades to restore CommonJS compatibility and resolve loading issues.

Fixes #12